### PR TITLE
fix(build): Simplified build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project contains community scenarios for Swipe for Future.
 
 For the following steps, replace `[SCENARIO_ID]` with the name of the folder in `scripts/scenarios/` where your scenario exists. For example, use `default` to get started.
 
-1. `npm run dev` will automatically rebuild scenarios from `scripts/scenarios/[SCENARIO_ID]` into playable scenarios in JSON format that will be available in `dist/[SCENARIO_ID]`.
+1. `npm run dev` will automatically rebuild all scenarios from `scripts/scenarios/[SCENARIO_ID]` into playable scenarios in JSON format that will be available in `dist/[SCENARIO_ID]`. If you only want to watch a specific scenario, use `npm run dev [SCENARIO_ID]`.
 2. In another terminal, start `npm run serve` to serve scenarios on `http://localhost:5000`
 3. Test scenarios using `https://swipeforfuture.com/?path=http://localhost:5000/[SCENARIO_ID]`
 


### PR DESCRIPTION
Fix #5 

This will output the same scenarios as before. The two only differences are a cleaner implementation, and that the scenario manifest now will build even when you only build specific scenarios.