### PR TITLE
Fix/improve error handling for builds

### DIFF
--- a/scripts/build-scenario.ts
+++ b/scripts/build-scenario.ts
@@ -71,7 +71,7 @@ function getScenarioIds(path: string): string[] {
     )
 }
 
-function buildScenarioManifest(ids: string[], outputDir: string) {
+async function buildScenarioManifest(ids: string[], outputDir: string) {
     const manifest: ScenarioManifest = {
         buildDate: new Date().toISOString(),
         scenarios: {},
@@ -80,6 +80,8 @@ function buildScenarioManifest(ids: string[], outputDir: string) {
     ids.forEach((id) => {
         manifest.scenarios[id] = {}
     })
+
+    await mkdir(outputDir, { recursive: true })
 
     return writeFile(
         join(outputDir, MANIFEST_FILENAME),

--- a/scripts/build-scenario.ts
+++ b/scripts/build-scenario.ts
@@ -106,6 +106,10 @@ if (require.main === module) {
     const allScenarioIds = getScenarioIds(join(__dirname, "scenarios"))
     const ids = id === "*" ? allScenarioIds : [id]
 
-    buildScenarios(ids, outputDir)
-    buildScenarioManifest(allScenarioIds, outputDir)
+    Promise.all([
+        buildScenarios(ids, outputDir),
+        buildScenarioManifest(allScenarioIds, outputDir),
+    ]).catch((reason: string) => {
+        console.error("❌ Build error: ", reason)
+    })
 }


### PR DESCRIPTION
With this PR...
1. `buildScenarioManifest()` will now make the `outputDir` if it doesn't exist.
2. Build exceptions will now be handled with a clear logging output like below.

![image](https://user-images.githubusercontent.com/6125097/98481828-74813780-21fd-11eb-8e6d-44107289af4f.png)

To test:
1. `rm -rf dist`
2. `npm run dev`
3. All scenarios should build without problems.