### PR TITLE
feat: add support for modifiers to trees and modifiers on leaves

### DIFF
--- a/scripts/scenarios/donuts/tree-test.ts
+++ b/scripts/scenarios/donuts/tree-test.ts
@@ -1,4 +1,9 @@
-import { cardContent, CardTree, cardsFromTree } from "../../content-utils"
+import {
+    cardContent,
+    CardTree,
+    cardsFromTree,
+    addModifier,
+} from "../../content-utils"
 import * as Stats from "./stats"
 
 function quickCard(name: string, left: string, right: string) {
@@ -18,19 +23,49 @@ export const tree: CardTree = {
         card: quickCard("A:L", "A:L:L", "A:L:R"),
         left: {
             card: quickCard("A:L:L", "A:L:L:L", "A:L:L:R"),
+            modifiers: addModifier({ left: 1 }),
+            left: {
+                modifiers: addModifier({ left: 1 }),
+            },
+            right: {
+                modifiers: addModifier({ right: 1 }),
+            },
         },
         right: {
             card: quickCard("A:L:R", "A:L:R:L", "A:L:R:R"),
+            modifiers: addModifier({ right: 1 }),
+            left: {
+                modifiers: addModifier({ left: 1 }),
+            },
+            right: {
+                modifiers: addModifier({ right: 1 }),
+            },
         },
+        modifiers: addModifier({ left: 1 }),
     },
     right: {
         card: quickCard("A:R", "A:R:L", "A:R:R"),
         left: {
             card: quickCard("A:R:L", "A:R:L:L", "A:R:L:R"),
+            modifiers: addModifier({ left: 1 }),
+            left: {
+                modifiers: addModifier({ left: 1 }),
+            },
+            right: {
+                modifiers: addModifier({ right: 1 }),
+            },
         },
         right: {
             card: quickCard("A:R:R", "A:R:R:L", "A:R:R:R"),
+            modifiers: addModifier({ right: 1 }),
+            left: {
+                modifiers: addModifier({ left: 1 }),
+            },
+            right: {
+                modifiers: addModifier({ right: 1 }),
+            },
         },
+        modifiers: addModifier({ right: 1 }),
     },
 }
 


### PR DESCRIPTION
This MR intends to add support for using modifiers in card trees. It should:
* Rename actions to modifers
* Create a leaf type which does not need a card in order to support modifiers on leaf decisions
* Include modifiers in the output of the cards