### PR TITLE
Feature/update card logic to use modifiers instead of actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",
         "build": "ts-node scripts/build-scenario.ts",
+        "start": "npm run dev",
         "dev": "ts-node-dev --respawn --transpile-only scripts/build-scenario.ts",
         "serve": "serve dist -p 5000 -C",
         "prettify": "npx prettier \"scripts/**/*\" --write",

--- a/scripts/content-utils/card-tree.ts
+++ b/scripts/content-utils/card-tree.ts
@@ -5,7 +5,6 @@ import {
     GameWorldModifier,
     cardRef,
     cardLogic,
-    action,
     setModifier,
     combineWorldQueries,
 } from "./"
@@ -54,7 +53,7 @@ export function cardsFromTree(
                 }),
             ),
             [
-                action([
+                [
                     ...mixToArray(tree.left?.modifiers),
                     setModifier(
                         {},
@@ -64,8 +63,8 @@ export function cardsFromTree(
                             ...triggerRefRemoval,
                         },
                     ),
-                ]),
-                action([
+                ],
+                [
                     ...mixToArray(tree.right?.modifiers),
                     setModifier(
                         {},
@@ -75,7 +74,7 @@ export function cardsFromTree(
                             ...triggerRefRemoval,
                         },
                     ),
-                ]),
+                ],
             ],
         ),
         ...(tree.left && "card" in tree.left

--- a/scripts/content-utils/card-utils.ts
+++ b/scripts/content-utils/card-utils.ts
@@ -81,7 +81,7 @@ export function cardLogic(
  * Given a generic card this creates a new event card with updated logic content.
  *
  * @param card A card template that contains artistic content
- * @param [left, right] The left and right world actions
+ * @param [left, right] The left and right EventCardActionData, containing modifiers and nextEventCardId
  */
 export function eventCardLogic(
     card: BaseCard,

--- a/scripts/content-utils/card-utils.ts
+++ b/scripts/content-utils/card-utils.ts
@@ -6,7 +6,10 @@ import {
     addModifier,
     action,
 } from "."
-import { EventCardActionData } from "../../swipeforfuture.com/src/game/ContentTypes"
+import {
+    EventCardActionData,
+    GameWorldModifier,
+} from "../../swipeforfuture.com/src/game/ContentTypes"
 
 export type BaseCard = Omit<CardData, "type" | "isAvailableWhen">
 
@@ -44,13 +47,16 @@ export function cardContent(
  *
  * @param card A card template that contains artistic content
  * @param isAvailableWhen The worldqueries for when the card is availables
- * @param [left, right] The left and right world actions
+ * @param [left, right] The left and right GameWorldModifiers
  * @param weight The weight of the card
  */
 export function cardLogic(
     card: BaseCard,
     isAvailableWhen: WorldQuery[],
-    [left, right]: [CardActionData, CardActionData],
+    [left, right]: [
+        GameWorldModifier | GameWorldModifier[],
+        GameWorldModifier | GameWorldModifier[],
+    ],
     weight: number = 1,
 ): CardData {
     return {
@@ -59,12 +65,12 @@ export function cardLogic(
         isAvailableWhen,
         actions: {
             left: {
-                ...left,
                 description: card.actions.left.description,
+                modifiers: Array.isArray(left) ? left : [left],
             },
             right: {
-                ...right,
                 description: card.actions.right.description,
+                modifiers: Array.isArray(right) ? right : [right],
             },
         },
         type: "card",

--- a/scripts/content-utils/card-utils.ts
+++ b/scripts/content-utils/card-utils.ts
@@ -1,11 +1,4 @@
-import {
-    CardData,
-    EventCard,
-    CardActionData,
-    WorldQuery,
-    addModifier,
-    action,
-} from "."
+import { CardData, EventCard, WorldQuery, addModifier, action } from "."
 import {
     EventCardActionData,
     GameWorldModifier,
@@ -81,22 +74,41 @@ export function cardLogic(
  * Given a generic card this creates a new event card with updated logic content.
  *
  * @param card A card template that contains artistic content
- * @param [left, right] The left and right EventCardActionData, containing modifiers and nextEventCardId
+ * @param [left, right] The left and right modifiers and nextEventCardId
  */
 export function eventCardLogic(
     card: BaseCard,
-    [left, right]: [EventCardActionData, EventCardActionData],
+    [
+        [leftModifiers, leftNextEventCardId = null],
+        [rightModifiers, rightNextEventCardId = null],
+    ]: [
+        [
+            GameWorldModifier | GameWorldModifier[],
+            EventCardActionData["nextEventCardId"]?,
+        ],
+        [
+            GameWorldModifier | GameWorldModifier[],
+            EventCardActionData["nextEventCardId"]?,
+        ],
+    ],
     weight: CardData["weight"] = 1,
 ): EventCard {
     return {
         ...card,
+        weight,
         actions: {
             left: {
-                ...left,
+                modifiers: Array.isArray(leftModifiers)
+                    ? leftModifiers
+                    : [leftModifiers],
+                nextEventCardId: leftNextEventCardId,
                 description: card.actions.left.description,
             },
             right: {
-                ...right,
+                modifiers: Array.isArray(rightModifiers)
+                    ? rightModifiers
+                    : [rightModifiers],
+                nextEventCardId: rightNextEventCardId,
                 description: card.actions.right.description,
             },
         },

--- a/scripts/scenarios/donuts/administration/daily-grind.ts
+++ b/scripts/scenarios/donuts/administration/daily-grind.ts
@@ -4,7 +4,6 @@ import {
     worldQuery,
     cardContent,
     cardLogic,
-    action,
     addModifier,
 } from "../../../content-utils"
 import { getImage } from "../image"
@@ -56,7 +55,7 @@ export const cards: CardData[] = [
                 ...alwaysState,
             }),
         ],
-        [action(addModifier()), action(addModifier())],
+        [addModifier(), addModifier()],
         1,
     ),
     cardLogic(
@@ -66,7 +65,7 @@ export const cards: CardData[] = [
                 ...morningState,
             }),
         ],
-        [action(addModifier()), action(addModifier())],
+        [addModifier(), addModifier()],
         1,
     ),
     cardLogic(
@@ -76,7 +75,7 @@ export const cards: CardData[] = [
                 ...noonState,
             }),
         ],
-        [action(addModifier({ [staffPatience]: -1 })), action(addModifier())],
+        [addModifier({ [staffPatience]: -1 }), addModifier()],
         1,
     ),
     cardLogic(
@@ -86,7 +85,7 @@ export const cards: CardData[] = [
                 ...afterNoonState,
             }),
         ],
-        [action(addModifier({ [staffPatience]: -1 })), action(addModifier())],
+        [addModifier({ [staffPatience]: -1 }), addModifier()],
         1,
     ),
 ]

--- a/scripts/scenarios/donuts/administration/introduction.ts
+++ b/scripts/scenarios/donuts/administration/introduction.ts
@@ -5,10 +5,8 @@ import {
     cardRef,
     cardContent,
     eventCardLogic,
-    eventCardAction,
     setModifier,
     addModifier,
-    action,
 } from "../../../content-utils"
 import { introductionComplete, staffPatience } from "./admin-state"
 import { getImage } from "../image"
@@ -58,32 +56,29 @@ const welcomeLunchCard = cardContent(
 
 export const eventCards: { [x: string]: EventCard } = {
     [welcome]: eventCardLogic(welcomeCard, [
-        eventCardAction(action(setModifier(), welcomeLoop)),
-        eventCardAction(action(setModifier(), welcomeLunch)),
+        [setModifier(), welcomeLoop],
+        [setModifier(), welcomeLunch],
+    ]),
+    [welcome]: eventCardLogic(welcomeCard, [
+        [setModifier(), welcomeLoop],
+        [setModifier(), welcomeLunch],
     ]),
     [welcomeLoop]: eventCardLogic(enforceLunchCard, [
-        eventCardAction(
-            action(addModifier({ [staffPatience]: -1 })),
-            welcomeLoop,
-        ),
-        eventCardAction(action(setModifier(), welcomeLunch)),
+        [addModifier({ [staffPatience]: -1 }), welcomeLoop],
+        [setModifier(), welcomeLunch],
     ]),
     [welcomeLunch]: eventCardLogic(welcomeLunchCard, [
-        eventCardAction(
-            action(
-                setModifier(
-                    { [Stats.money]: 70, [Stats.popularity]: 52 },
-                    { [introductionComplete]: true },
-                ),
+        [
+            setModifier(
+                { [Stats.money]: 70, [Stats.popularity]: 52 },
+                { [introductionComplete]: true },
             ),
-        ),
-        eventCardAction(
-            action(
-                setModifier(
-                    { [Stats.environment]: 70, [Stats.popularity]: 65 },
-                    { [introductionComplete]: true },
-                ),
+        ],
+        [
+            setModifier(
+                { [Stats.environment]: 70, [Stats.popularity]: 65 },
+                { [introductionComplete]: true },
             ),
-        ),
+        ],
     ]),
 }


### PR DESCRIPTION
This PR will...
- Simplify `cardLogic()` to support one or multiple `GameWorldModifier`s instead of passing in actions. This will complete the separation of `cardContent()` and `cardLogic()`
- Update scenarios to take advantage of the new `cardLogic()` API which removes some empty `action()` calls.
- Also update the same for `eventCardLogic()`
- Add `npm start` script as an alias for `npm run dev` (which is clearly too long to type) 😅



Resolve https://github.com/Muthaias/swipeforfuture-content/issues/9